### PR TITLE
add info in a metrics logging

### DIFF
--- a/src/han/main.py
+++ b/src/han/main.py
@@ -265,6 +265,7 @@ def train(epoch,net,dataset,device,msg="val/test",optimize=False,optimizer=None,
 
     if scheduler:
         scheduler.step()
+    logger.info("Epoch {} - {} {}".format(epoch, msg, dic_metrics))
 
 
 def save(net,dic,path):


### PR DESCRIPTION
Add info about epoch and a msg (dataset info) in a metrics logging, that will improve readability of them